### PR TITLE
Refresh

### DIFF
--- a/misfit/exceptions.py
+++ b/misfit/exceptions.py
@@ -30,7 +30,7 @@ class MisfitHttpException(MisfitException):
         code = exc.response.status_code if hasattr(exc, 'response') else 500
         message = exc.message if hasattr(exc, 'message') else 'Unknown error'
         try:
-            json_content = json.loads(exc.content)
+            json_content = json.loads(exc.content.decode('utf8'))
         except ValueError:
             pass
         else:

--- a/misfit/notification.py
+++ b/misfit/notification.py
@@ -53,8 +53,7 @@ class MisfitNotification(MisfitObject):
         raises cryptography.exceptions.InvalidSignature
         """
         # Get the signing certificate and public key from the specified URL
-        cert_url = self.data['SigningCertURL']
-        cert_str = requests.get(cert_url).content.encode('utf8')
+        cert_str = requests.get(self.data['SigningCertURL']).content
         cert = default_backend().load_pem_x509_certificate(cert_str)
         pubkey = cert.public_key()
         # Verify the signature

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 arrow>0.5.4,<0.7
-cryptography>=0.7,<1.1
+cryptography>=1.2,<1.6
 CherryPy>=3.6,<3.9
 docopt>=0.6,<0.7
 requests-oauthlib>=0.4,<0.6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 arrow>0.5.4,<0.7
-cryptography>=1.2,<1.6
+cryptography>=1.2
 CherryPy>=3.6,<3.9
 docopt>=0.6,<0.7
 requests-oauthlib>=0.4,<0.6


### PR DESCRIPTION
@orcasgit/orcas-developers The version range specified in requirements is not installable with modern openssl installations, so I updated it (and removed the ceiling so this doesn't happen again). The upgrade caused some tests to break so I made some changes to fix them.